### PR TITLE
Simplify default calib file handing

### DIFF
--- a/consts/resource_paths.py
+++ b/consts/resource_paths.py
@@ -12,13 +12,9 @@ blob_config_fpath = './resources/nn/object_detection_4shave/object_detection.jso
 
 if path.exists('./resources/depthai.calib'):
     calib_fpath = './resources/depthai.calib'
-    print("Using Calibration File: depthai.calib")
-
-elif path.exists('./resources/default.calib'):
-    calib_fpath = './resources/default.calib'
-    print("Using Calibration File: default.calib")
-
+    print("Using Custom Calibration File: depthai.calib")
 else:
-    print("ERROR: NO CALIBRATION FILE")
+    calib_fpath = ''
+    print("No calibration file. Using Calibration Defaults.")
 
 pipeline_config_fpath = './resources/config.json'


### PR DESCRIPTION
If an empty string (`''`) is passed as the `calibration_file` value, a default
calib setting will be used by DepthAI. Message from the console:

```
depthai: Calibration file is not specified, will use default setting;
```

So, I think we can collapse the file handling a bit.

/cc @Luxonis-Brian 