### PR TITLE
Adds --config-overwrite to test.py

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -1,5 +1,6 @@
 import depthai
-from  calibration_utils import *
+from depthai_helpers.calibration_utils import *
+from depthai_helpers import utils
 import argparse
 from argparse import ArgumentParser
 import time
@@ -128,7 +129,7 @@ if 'capture' in args['mode']:
     }
 
     if args['config_overwrite'] is not None:
-        config = merge(args['config_overwrite'],config)
+        config = utils.merge(args['config_overwrite'],config)
         print("Merged Pipeline config with overwrite",config)
 
     pipeline = depthai.create_pipeline(config)

--- a/depthai_helpers/calibration_utils.py
+++ b/depthai_helpers/calibration_utils.py
@@ -6,32 +6,6 @@ import numpy as np
 import re
 import time
 
-# https://stackoverflow.com/questions/20656135/python-deep-merge-dictionary-data#20666342
-def merge(source, destination):
-    """
-    run me with nosetests --with-doctest file.py
-
-    >>> a = { 'first' : { 'all_rows' : { 'pass' : 'dog', 'number' : '1' } } }
-    >>> b = { 'first' : { 'all_rows' : { 'fail' : 'cat', 'number' : '5' } } }
-    >>> merge(b, a) == { 'first' : { 'all_rows' : { 'pass' : 'dog', 'fail' : 'cat', 'number' : '5' } } }
-    True
-    """
-    for key, value in source.items():
-        if isinstance(value, dict):
-            # get node or create one
-            node = destination.setdefault(key, {})
-            merge(value, node)
-        else:
-            destination[key] = value
-
-    return destination
-def mkdir_overwrite(dir):
-    if not os.path.exists(dir):
-        os.makedirs(dir)
-    else:
-        shutil.rmtree(dir)
-        os.makedirs(dir)
-
 # Creates a set of 13 polygon coordinates
 def setPolygonCoordinates(height, width):
     horizontal_shift = width//4

--- a/depthai_helpers/utils.py
+++ b/depthai_helpers/utils.py
@@ -1,0 +1,25 @@
+# https://stackoverflow.com/questions/20656135/python-deep-merge-dictionary-data#20666342
+def merge(source, destination):
+    """
+    run me with nosetests --with-doctest file.py
+
+    >>> a = { 'first' : { 'all_rows' : { 'pass' : 'dog', 'number' : '1' } } }
+    >>> b = { 'first' : { 'all_rows' : { 'fail' : 'cat', 'number' : '5' } } }
+    >>> merge(b, a) == { 'first' : { 'all_rows' : { 'pass' : 'dog', 'fail' : 'cat', 'number' : '5' } } }
+    True
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            merge(value, node)
+        else:
+            destination[key] = value
+
+    return destination
+def mkdir_overwrite(dir):
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+    else:
+        shutil.rmtree(dir)
+        os.makedirs(dir)


### PR DESCRIPTION
This adds the ability to overwrite the default config via a script argument. It works the same as the calibrate.py.

Additionally:

* Puts utils in a dedicated `depthai_helpers` folder
* For utils shared by both calibrate and test, adds a depthai_helpers.utils module